### PR TITLE
Fix gripper plugin compilation and minor enhancement

### DIFF
--- a/plugins/src/plugins/gripper/gripper.cpp
+++ b/plugins/src/plugins/gripper/gripper.cpp
@@ -262,17 +262,23 @@ void Gripper::sendHasPuck(bool has_puck)
  */
 gazebo::physics::LinkPtr Gripper::getGripperLink()
 {
+  // XXX: Switch to 'constexpr linkLen = length("gripper::link")' in c++11
+  static const short int linkLen = strlen("gripper::link");
+
+  // Search for gripper in model
   physics::LinkPtr res = model_->GetLink("gripper::link");
   if(res)
     return res;
-  //search for gripper link in included submodels
+
+  // Search for gripper link in included submodels
   std::vector<physics::LinkPtr> links = model_->GetLinks();
   for(std::vector<physics::LinkPtr>::iterator it = links.begin(); it != links.end(); it++)
   {
     printf("Checking %s\n", (*it)->GetName().c_str());
-    if((*it)->GetName().find("gripper::link") != std::string::npos)
+    if((*it)->GetName().rfind("gripper::link", (*it)->GetName().length()-linkLen) != std::string::npos)
       return (*it);
   }
   printf("Could not find gripper link of model %s\n", name_.c_str());
-  return NULL;
+
+  return res;
 }


### PR DESCRIPTION
Return empty (null) shared_ptr rather than NULL (wich could fail compilation).

Change std::string::find for std::string::rfind function in getGripperLink and limit research to length("gripper::link") chars since "gripper::link" should be the end part of link name.

Works fine with a gripper directly included in the robotino model. Did not test it with submodels.