### PR TITLE
Conveyor and slide pose TFs updates

### DIFF
--- a/models/carologistics/carologistics-robotino-3/model.sdf
+++ b/models/carologistics/carologistics-robotino-3/model.sdf
@@ -42,6 +42,16 @@
       <pose>0.1 0 0.57 0 0 0</pose>
     </include>
 
+    <link name="base_link">
+      <pose>0 0 0.01 0 0 0</pose>	
+    </link>
+
+    <joint name="base_link_joint" type="fixed">
+      <child>base_link</child>
+      <parent>robotino3::body</parent>
+      <pose>0 0 0 0 0 0</pose>
+    </joint>
+
     <joint name="sick_joint" type="revolute">
       <child>sick_laser::link</child>
       <parent>robotino3::body</parent>

--- a/plugins/cfg/config.yaml
+++ b/plugins/cfg/config.yaml
@@ -41,7 +41,9 @@ plugins:
     number_pucks: 20
     #how far is the center of the belt hsifted from the machine center
     belt_offset_side: 0.025
-    #radius of the area where a workpiece is detected by the machine
+    #how far is the center of the belt hsifted from the machine center
+    slide_offset_side: -0.25
+    #radius of the area where a workpiece is detected by the machinie
     detect_tolerance: 0.06
     #radius of a workpiece
     puck_size: 0.02

--- a/plugins/cfg/config.yaml
+++ b/plugins/cfg/config.yaml
@@ -114,7 +114,7 @@ plugins:
     topic-set-conveyor: "~/RobotinoSim/SetConveyor/"
     topic-holds-puck: "~/RobotinoSim/GripperHasPuck/"
     topic-joint: "/GripperJoints/Holding"
-    radius-grab-area: 0.05
+    radius-grab-area: 0.1
 
   light-control:
     topic-instruct-machine: "~/LLSFRbSim/InstructMachine/"

--- a/plugins/src/libs/llsf_msgs/ConveyorVisionResult.proto
+++ b/plugins/src/libs/llsf_msgs/ConveyorVisionResult.proto
@@ -19,5 +19,6 @@ message ConveyorVisionResult {
   }
 
   // List of all known pucks
-  required Pose3D positions = 1;
+  required Pose3D conveyor = 1;
+  optional Pose3D slide = 2;
 }

--- a/plugins/src/libs/utils/misc/gazebo_api_wrappers.h
+++ b/plugins/src/libs/utils/misc/gazebo_api_wrappers.h
@@ -33,9 +33,17 @@
 # define GZWRAP_Z Z()
 # define GZWRAP_W W()
 
+# define GZWRAP_ROLL Roll()
+# define GZWRAP_PITCH  Pitch()
+# define GZWRAP_YAW  Yaw()
+
 # define GZWRAP_ROT_ROLL Rot().Roll()
 # define GZWRAP_ROT_PITCH Rot().Pitch()
 # define GZWRAP_ROT_YAW Rot().Yaw()
+
+# define GZWRAP_ROTATE_POSE RotatePositionAboutOrigin()
+# define GZWRAP_ROT_ADD CoordRotationAdd
+# define GZWRAP_ROT_SUB CoordRotationSub
 
 #else
 
@@ -65,9 +73,16 @@
 # define GZWRAP_Z z
 # define GZWRAP_W w
 
+# define GZWRAP_ROLL GetRoll()
+# define GZWRAP_PITCH GetPitch()
+# define GZWRAP_YAW GetYaw()
+
 # define GZWRAP_ROT_ROLL rot.GetRoll()
 # define GZWRAP_ROT_PITCH rot.GetPitch()
 # define GZWRAP_ROT_YAW rot.GetYaw()
+# define GZWRAP_ROTATE_POSE RotatePositionAboutOrigin()
+# define GZWRAP_ROT_ADD CoordRotationAdd
+# define GZWRAP_ROT_SUB CoordRotationSub
 
 #endif
 
@@ -84,14 +99,17 @@
 # define GZWRAP_ROT_EULER_Y GZWRAP_ROT.GZWRAP_EULER.GZWRAP_Y
 # define GZWRAP_ROT_EULER_Z GZWRAP_ROT.GZWRAP_EULER.GZWRAP_Z
 
+
 namespace gzwrap {
 
 #if GAZEBO_MAJOR_VERSION >= 8
 typedef ignition::math::Pose3d Pose3d;
 typedef ignition::math::Vector3d Vector3d;
+typedef ignition::math::Quaterniond Quaterniond;
 #else
 typedef gazebo::math::Pose Pose3d;
 typedef gazebo::math::Vector3 Vector3d;
+typedef gazebo::math::Quaternion Quaterniond;
 #endif
 
 } // namespace gazebo_wrappers

--- a/plugins/src/plugins/conveyor-vision/conveyor_vision.cpp
+++ b/plugins/src/plugins/conveyor-vision/conveyor_vision.cpp
@@ -189,7 +189,7 @@ void ConveyorVision::send_conveyor_result()
       pose->set_z(res.GZWRAP_POS_Z);
       pose->set_ori_x(res.GZWRAP_ROT_X);
       pose->set_ori_y(res.GZWRAP_ROT_Y);
-      pose->set_ori_z(0);
+      pose->set_ori_z(res.GZWRAP_ROT_Z);
       pose->set_ori_w(res.GZWRAP_ROT_W);
       conv_msg.set_allocated_positions(pose);
       //send

--- a/plugins/src/plugins/conveyor-vision/conveyor_vision.cpp
+++ b/plugins/src/plugins/conveyor-vision/conveyor_vision.cpp
@@ -175,12 +175,10 @@ void ConveyorVision::send_conveyor_result()
         res = output_pose - camera_pose;
       }
       //get position in the camera frame
-      //printf("conv-res: (%f,%f,%f)\n", res.pos.x, res.pos.y, res.pos.z);
       llsf_msgs::ConveyorVisionResult conv_msg;
       llsf_msgs::Pose3D *pose = new llsf_msgs::Pose3D();
       pose->set_x(res.GZWRAP_POS_X);
       pose->set_y(res.GZWRAP_POS_Y);
-      //pose->set_z(res.z);
       //set z to 0.005 as default so that no z alignment of the gripper is necessary
       pose->set_z( offset_z_ );
       pose->set_ori_x(res.GZWRAP_ROT_X);

--- a/plugins/src/plugins/conveyor-vision/conveyor_vision.cpp
+++ b/plugins/src/plugins/conveyor-vision/conveyor_vision.cpp
@@ -183,10 +183,10 @@ void ConveyorVision::send_conveyor_result()
       //pose->set_z(res.z);
       //set z to 0.005 as default so that no z alignment of the gripper is necessary
       pose->set_z( offset_z_ );
-      pose->set_ori_x(0);
-      pose->set_ori_y(0);
-      pose->set_ori_z(0);
-      pose->set_ori_w(0);
+      pose->set_ori_x(res.GZWRAP_ROT_X);
+      pose->set_ori_y(res.GZWRAP_ROT_Y);
+      pose->set_ori_z(res.GZWRAP_ROT_Z);
+      pose->set_ori_w(res.GZWRAP_ROT_W);
       conv_msg.set_allocated_positions(pose);
       //send
       conveyor_pub_->Publish(conv_msg);

--- a/plugins/src/plugins/conveyor-vision/conveyor_vision.h
+++ b/plugins/src/plugins/conveyor-vision/conveyor_vision.h
@@ -38,6 +38,8 @@
 #define NUMBER_PUCKS number_pucks_
 //how far is the center of the belt hsifted from the machine center
 #define BELT_OFFSET_SIDE belt_offset_side_
+//how far is the center of the slide hsifted from the machine center
+#define SLIDE_OFFSET slide_offset_side_
 //radius of the area where a workpiece is detected by the machine
 #define DETECT_TOLERANCE detect_tolerance_
 //radius of a workpiece
@@ -91,6 +93,8 @@ namespace gazebo
     int number_pucks_;
     //how far is the center of the belt hsifted from the machine center
     float belt_offset_side_;
+    //how far is the center of the slide hsifted from the machine center
+    float slide_offset_side_;
     //radius of the area where a workpiece is detected by the machine
     float detect_tolerance_;
     //radius of a workpiece

--- a/plugins/src/plugins/gripper/gripper.h
+++ b/plugins/src/plugins/gripper/gripper.h
@@ -27,6 +27,7 @@
 #include <list>
 #include <string.h>
 #include <fnmatch.h>
+#include <queue>
 
 #include <boost/thread/mutex.hpp>
 #include <configurable/configurable.h>
@@ -42,7 +43,8 @@
 enum ActionOnUpdate{
   NOTHING = 0,
   OPEN = 1,
-  CLOSE = 2
+  CLOSE = 2,
+  MOVE = 3
 } typedef ActionOnUpdate;
 
 namespace gazebo
@@ -103,6 +105,9 @@ namespace gazebo
     gazebo::physics::ModelPtr getNearestPuck();
 
     ActionOnUpdate last_action_rcvd_;
+    std::queue<ActionOnUpdate> message_queue_;
+    double action_duration_;
+    double last_action_time_;
 
     gazebo::physics::LinkPtr getGripperLink();
   };


### PR DESCRIPTION
Updates to TFs published for conveyor and slide:
+Publishing relative to baselink
+Seperate TF for conveyor and slide

Conveyor TFs have the same orientation as baselink  (positive X points twards conveyor mid-point and positve z poiting upwards)
For the outputside:  I=====O  <--- x
For the input side:  :x---> I=====O



(In the context of adapting to the new gripper hardware and the related skills)