### PR TITLE
buildsys: do not build with -mnative, also switch to -O2

### DIFF
--- a/plugins/etc/buildsys/btypes/config_fawkes.mk
+++ b/plugins/etc/buildsys/btypes/config_fawkes.mk
@@ -17,5 +17,5 @@ SYSROOT ?=
 
 # Add -DDEBUG_THREADING if you run into threading problems like deadlocks.
 # Read FawkesDebugging in the Fawkes Trac Wiki on how to use it
-CFLAGS_EXTRA ?=	-g -Wall -Werror $(CFLAGS_MTUNE_NATIVE) -O3
+CFLAGS_EXTRA ?=	-g -Wall -Werror -O2
 


### PR DESCRIPTION
We do not want to optimize too much as this brings little benefit and
has the big disadvantage that we cannot use the same binaries on
different (but similar x86-64) machines.