### PR TITLE
delivery station: do not require gate information

### DIFF
--- a/plugins/src/plugins/mps/delivery_station.h
+++ b/plugins/src/plugins/mps/delivery_station.h
@@ -38,7 +38,7 @@ public:
   void on_instruct_machine_msg(ConstInstructMachinePtr &msg);
   void deliver();
 
-  uint selected_gate_;
+  bool prepared_;
   physics::ModelPtr puck_;
 };
 


### PR DESCRIPTION
The prepare message sent by a robot no longer contains information about
the delivery gate. As we use the same message also for propagating the
status to the delivery station, we also no longer receive the gate.
Thus, just always deliver on gate 1 for now. Only do that if the machine
has been prepared and there is some workpiece on the input (as before).