### PR TITLE
Reduce collision parts and add min_depth to all models to avoid teleporting robots

### DIFF
--- a/models/mps_base/model.sdf
+++ b/models/mps_base/model.sdf
@@ -50,6 +50,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_east">
         <pose>0.05 0 0.9 0 0 0 </pose>
@@ -58,6 +66,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
 
       <!-- Box -->
@@ -68,6 +84,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_south">
         <pose>0 -0.175 0.42 0 0 0 </pose>
@@ -76,6 +100,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_north">
         <pose>0 0.175 0.42 0 0 0 </pose>
@@ -84,6 +116,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <!-- On both ends of the mps are transparent walls a laser sensor can look through, in the middle are solid walls -->
       <collision name="collision_base_box_wall_middle_1">
@@ -93,6 +133,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_middle_2">
         <pose>0.035 0 0.42 0 0 0 </pose>
@@ -101,6 +149,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_top">
         <pose>0 0 0.78 0 0 0 </pose>
@@ -109,6 +165,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_wheels">
 	<!-- Collision to avoid that the box falls down (In reality done by wheels) -->
@@ -118,6 +182,14 @@
 	    <size>0.69 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
     </link>
 

--- a/models/mps_base/model.sdf
+++ b/models/mps_base/model.sdf
@@ -54,7 +54,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -70,7 +69,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -88,7 +86,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -104,7 +101,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -120,7 +116,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -137,7 +132,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -153,7 +147,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -169,7 +162,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -186,7 +178,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>

--- a/models/mps_base/model.sdf
+++ b/models/mps_base/model.sdf
@@ -42,6 +42,13 @@
 	    <size>0.03 0.35 0.04</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_west">
         <pose>0 0 0.9 0 0 0 </pose>

--- a/models/mps_cap/model.sdf
+++ b/models/mps_cap/model.sdf
@@ -41,6 +41,14 @@
 	    <size>0.295 0.12 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
 
 
@@ -60,6 +68,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_east">
         <pose>0.05 0 0.9 0 0 0 </pose>
@@ -68,6 +84,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
 
       <!-- Box -->
@@ -78,6 +102,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_south">
         <pose>0 -0.175 0.42 0 0 0 </pose>
@@ -86,6 +118,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_north">
         <pose>0 0.175 0.42 0 0 0 </pose>
@@ -94,6 +134,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <!-- On both ends of the mps are transparent walls a laser sensor can look through, in the middle are solid walls -->
       <collision name="collision_base_box_wall_middle_1">
@@ -103,6 +151,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_middle_2">
         <pose>0.035 0 0.42 0 0 0 </pose>
@@ -111,6 +167,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_top">
         <pose>0 0 0.78 0 0 0 </pose>
@@ -119,6 +183,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_wheels">
 	<!-- Collision to avoid that the box falls down (In reality done by wheels) -->
@@ -128,6 +200,14 @@
 	    <size>0.69 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <visual name="have_cap">
         <cast_shadows>false</cast_shadows>

--- a/models/mps_cap/model.sdf
+++ b/models/mps_cap/model.sdf
@@ -45,7 +45,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -72,7 +71,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -88,7 +86,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -106,7 +103,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -122,7 +118,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -138,7 +133,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -155,7 +149,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -171,7 +164,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -187,7 +179,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -204,7 +195,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>

--- a/models/mps_cap/model.sdf
+++ b/models/mps_cap/model.sdf
@@ -59,6 +59,13 @@
 	    <size>0.03 0.35 0.04</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_west">
         <pose>0 0 0.9 0 0 0 </pose>

--- a/models/mps_delivery/model.sdf
+++ b/models/mps_delivery/model.sdf
@@ -47,7 +47,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -63,7 +62,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -79,7 +77,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -97,7 +94,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -113,7 +109,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -129,7 +124,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -146,7 +140,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -162,7 +155,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -178,7 +170,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -195,7 +186,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>

--- a/models/mps_delivery/model.sdf
+++ b/models/mps_delivery/model.sdf
@@ -43,6 +43,14 @@
 	    <size>0.03 0.35 0.04</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_west">
         <pose>0 0 0.9 0 0 0 </pose>
@@ -51,6 +59,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_east">
         <pose>0.05 0 0.9 0 0 0 </pose>
@@ -59,6 +75,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
 
       <!-- Box -->
@@ -69,6 +93,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_south">
         <pose>0 -0.175 0.42 0 0 0 </pose>
@@ -77,6 +109,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_north">
         <pose>0 0.175 0.42 0 0 0 </pose>
@@ -85,6 +125,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <!-- On both ends of the mps are transparent walls a laser sensor can look through, in the middle are solid walls -->
       <collision name="collision_base_box_wall_middle_1">
@@ -94,6 +142,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_middle_2">
         <pose>0.035 0 0.42 0 0 0 </pose>
@@ -102,6 +158,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_top">
         <pose>0 0 0.78 0 0 0 </pose>
@@ -110,6 +174,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_wheels">
 	<!-- Collision to avoid that the box falls down (In reality done by wheels) -->
@@ -119,6 +191,14 @@
 	    <size>0.69 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
     </link>
 

--- a/models/mps_ring/model.sdf
+++ b/models/mps_ring/model.sdf
@@ -43,6 +43,14 @@
 	    <size>0.03 0.35 0.04</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_west">
         <pose>0 0 0.9 0 0 0 </pose>
@@ -51,6 +59,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_east">
         <pose>0.05 0 0.9 0 0 0 </pose>
@@ -59,6 +75,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
 
       <!-- Box -->
@@ -69,6 +93,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_south">
         <pose>0 -0.175 0.42 0 0 0 </pose>
@@ -77,6 +109,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_north">
         <pose>0 0.175 0.42 0 0 0 </pose>
@@ -85,6 +125,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <!-- On both ends of the mps are transparent walls a laser sensor can look through, in the middle are solid walls -->
       <collision name="collision_base_box_wall_middle_1">
@@ -94,6 +142,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_middle_2">
         <pose>0.035 0 0.42 0 0 0 </pose>
@@ -102,6 +158,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_top">
         <pose>0 0 0.78 0 0 0 </pose>
@@ -110,6 +174,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_wheels">
 	<!-- Collision to avoid that the box falls down (In reality done by wheels) -->
@@ -119,6 +191,14 @@
 	    <size>0.69 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <visual name="base_0">
         <cast_shadows>false</cast_shadows>

--- a/models/mps_ring/model.sdf
+++ b/models/mps_ring/model.sdf
@@ -47,7 +47,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -63,7 +62,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -79,7 +77,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -97,7 +94,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -113,7 +109,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -129,7 +124,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -146,7 +140,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -162,7 +155,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -178,7 +170,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -195,7 +186,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>

--- a/models/mps_storage/model.sdf
+++ b/models/mps_storage/model.sdf
@@ -46,7 +46,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -62,7 +61,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -78,7 +76,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -94,7 +91,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -110,7 +106,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -126,7 +121,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -142,7 +136,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -158,7 +151,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -174,7 +166,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -192,7 +183,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -208,7 +198,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -224,7 +213,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -241,7 +229,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -257,7 +244,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -273,7 +259,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>
@@ -290,7 +275,6 @@
           <contact>
             <ode>
               <min_depth>0.01</min_depth>
-              <max_vel>0.1</max_vel>
             </ode>
           </contact>
         </surface>

--- a/models/mps_storage/model.sdf
+++ b/models/mps_storage/model.sdf
@@ -42,6 +42,14 @@
             <size>0.0985 0.2 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="puckslot1">
         <pose>.1152 0 1.06275 0 0 0</pose>
@@ -50,6 +58,14 @@
             <size>0.0985 0.2 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="puckslot2">
         <pose>.1152 0 1.15275 0 0 0</pose>
@@ -58,6 +74,14 @@
             <size>0.0985 0.2 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="puckslot3">
         <pose>.1152 0 1.24275 0 0 0</pose>
@@ -66,6 +90,14 @@
             <size>0.0985 0.2 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="puckslot4">
         <pose>.1152 0 1.33275 0 0 0</pose>
@@ -74,6 +106,14 @@
             <size>0.0985 0.2 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="puckslot5">
         <pose>.1152 0 1.42275 0 0 0</pose>
@@ -82,6 +122,14 @@
             <size>0.0985 0.2 0.002</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
         <collision name="collision_conveyor_belt">
         <pose>0.025 0 0.88 0 0 0 </pose>
@@ -90,6 +138,14 @@
 	    <size>0.03 0.35 0.04</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_west">
         <pose>0 0 0.9 0 0 0 </pose>
@@ -98,6 +154,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_conveyor_belt_border_east">
         <pose>0.05 0 0.9 0 0 0 </pose>
@@ -106,6 +170,14 @@
 	    <size>0.01 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
 
       <!-- Box -->
@@ -116,6 +188,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_south">
         <pose>0 -0.175 0.42 0 0 0 </pose>
@@ -124,6 +204,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_north">
         <pose>0 0.175 0.42 0 0 0 </pose>
@@ -132,6 +220,14 @@
 	    <size>0.69 0.01 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <!-- On both ends of the mps are transparent walls a laser sensor can look through, in the middle are solid walls -->
       <collision name="collision_base_box_wall_middle_1">
@@ -141,6 +237,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_wall_middle_2">
         <pose>0.035 0 0.42 0 0 0 </pose>
@@ -149,6 +253,14 @@
 	    <size>0.01 0.35 0.72</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_base_box_top">
         <pose>0 0 0.78 0 0 0 </pose>
@@ -157,6 +269,14 @@
 	    <size>0.69 0.35 0.01</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
       <collision name="collision_wheels">
 	<!-- Collision to avoid that the box falls down (In reality done by wheels) -->
@@ -166,6 +286,14 @@
 	    <size>0.69 0.35 0.02</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <min_depth>0.01</min_depth>
+              <max_vel>0.1</max_vel>
+            </ode>
+          </contact>
+        </surface>
       </collision>
     </link>
 

--- a/models/robotino3/model.sdf
+++ b/models/robotino3/model.sdf
@@ -47,8 +47,7 @@
           </friction>
           <contact>
             <ode>
-              <max_vel>0.1</max_vel>
-              <min_depth>0.01</min_depth>
+              <min_depth>0.05</min_depth>
             </ode>
           </contact>
         </surface>

--- a/models/robotino3/model.sdf
+++ b/models/robotino3/model.sdf
@@ -47,32 +47,15 @@
           </friction>
         </surface>
       </collision>
-      <collision name="body-collision-computer">
-        <pose>2.869 -1.87 0.19 0 0 1.95</pose>
-        <geometry>
-          <mesh>
-            <uri>model://robotino3/meshes/robotino-3-computer.dae</uri>
-          </mesh>
-        </geometry>
-      </collision>
-      <!--<collision name="chassis-collision-for-laser">
-        <pose>-0.05 0 0.17 0 0 0</pose>
-        <geometry>
-          <cylinder>
-            <length>0.08</length>
-            <radius>0.12</radius>
-          </cylinder>
-        </geometry>
-      </collision>-->
-      <collision name="tower">
+      <visual name="tower">
         <pose>0.00 0.00 0.43 0 0 0</pose>
         <geometry>
           <box>
             <size>0.09 0.09 0.70</size>
           </box>
         </geometry>
-      </collision>
-      <collision name="tower_plate">
+      </visual>
+      <visual name="tower_plate">
         <pose>0 0 0.79 0 0 0</pose>
         <geometry>
           <cylinder>
@@ -80,7 +63,7 @@
             <radius>0.225</radius>
           </cylinder>
         </geometry>
-      </collision>
+      </visual>
     </link>
 	
     <plugin name="Motor" filename="libmotor.so"/>

--- a/models/robotino3/model.sdf
+++ b/models/robotino3/model.sdf
@@ -45,6 +45,12 @@
               <slip2>0.8</slip2>
             </ode>
           </friction>
+          <contact>
+            <ode>
+              <max_vel>0.1</max_vel>
+              <min_depth>0.01</min_depth>
+            </ode>
+          </contact>
         </surface>
       </collision>
       <visual name="tower">

--- a/models/workpiece_base/model.sdf
+++ b/models/workpiece_base/model.sdf
@@ -26,7 +26,6 @@
       	  </friction>
           <contact>
             <ode>
-              <max_vel>0.1</max_vel>
               <min_depth>0.01</min_depth>
             </ode>
           </contact>

--- a/models/workpiece_base/model.sdf
+++ b/models/workpiece_base/model.sdf
@@ -24,6 +24,12 @@
               <slip2>0.0</slip2>
       	    </ode>
       	  </friction>
+          <contact>
+            <ode>
+              <max_vel>0.1</max_vel>
+              <min_depth>0.001</min_depth>
+            </ode>
+          </contact>
       	</surface>
       </collision>
       <visual name="cylinder_visual">

--- a/models/workpiece_base/model.sdf
+++ b/models/workpiece_base/model.sdf
@@ -27,7 +27,7 @@
           <contact>
             <ode>
               <max_vel>0.1</max_vel>
-              <min_depth>0.001</min_depth>
+              <min_depth>0.01</min_depth>
             </ode>
           </contact>
       	</surface>


### PR DESCRIPTION
This is an effort towards avoiding robots teleporting when they collide with other objects. One reason for those teleportations is a missing `min_depth` parameter in the collision surface model of the robots and MPS stations.

Also reduce the number of collision objects for the robotino to further avoid teleporting collisions.

This does not avoid teleportations completely but reduces them significantly.