### PR TITLE
Process DS delivery command asynchronously

### DIFF
--- a/plugins/src/plugins/mps/delivery_station.h
+++ b/plugins/src/plugins/mps/delivery_station.h
@@ -33,13 +33,7 @@ public:
 	DeliveryStation(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
 
 	void process_command_in();
-
-	void on_puck_msg(ConstPosePtr &msg);
 	void deliver();
-
-private:
-	bool     prepared_;
-	uint16_t slot_;
 };
 
 } // namespace gazebo

--- a/plugins/src/plugins/mps/durations.h
+++ b/plugins/src/plugins/mps/durations.h
@@ -23,7 +23,7 @@
 
 namespace gazebo {
 constexpr const std::chrono::milliseconds move_duration{2500};
-constexpr const std::chrono::milliseconds dispense_duration{1500};
+constexpr const std::chrono::milliseconds dispense_duration{2500};
 constexpr const std::chrono::milliseconds cap_op_duration{3500};
 constexpr const std::chrono::milliseconds deliver_duration{3500};
 constexpr const std::chrono::milliseconds ring_op_duration{3500};


### PR DESCRIPTION
Processing the command directly in the handler freezes the simulation
for a few seconds, resulting in delocalized robots (as they do not get
any updates from the simulation for that time). Those commands should be
processed asynchronously, as we already do for all other commands. For
some reason, we did not do this for the delivery station.

Fixes #42.