### PR TITLE
initialize all pucks with caps in OnUpdata function

### DIFF
--- a/plugins/src/plugins/mps/cap_station.h
+++ b/plugins/src/plugins/mps/cap_station.h
@@ -42,6 +42,8 @@ public:
 	void process_command_in() override;
 	void mount_cap();
 	void retrieve_cap();
+	void init_caps();
+	void spawn_three_pucks();
 
 	gzwrap::Pose3d shelf_left_pose();
 	gzwrap::Pose3d shelf_middle_pose();
@@ -58,8 +60,10 @@ public:
 	gazsim_msgs::Color stored_cap_color_;
 
 	transport::SubscriberPtr workpiece_result_subscriber_;
-
-	double puck_spawned_time_;
+	bool                     init_cap_state[3] = {false, false, false};
+	std::string              puck_name[3];
+	int                      updata_time = 0;
+	double                   puck_spawned_time_;
 };
 
 } // namespace gazebo


### PR DESCRIPTION
It seems that we cannot initialize all 4x3 (4 cap stations, 3 pucks each) pucks at the same time. Commands may be overwritten when they get too many commands at once. So I initialize the pucks in the `OnUpdata` function, which is called periodically, each time each cap station initializes a puck.
But it's not perfect, we always have to wait a few seconds to see the caps. I think the reason is that the pucks are generated immediately when the cap station is created, but it can be initialized with caps only after getting the puck model in the function `on_new_puck` . This will take some time.

<img width="629" alt="71cf1fa96d7369d4dfc2947a1a5fee2" src="https://user-images.githubusercontent.com/80486981/148955095-d68a8f5a-7ac2-4fa9-a1d3-9e5596289472.png">
