### PR TITLE
add missing linking against core lib in config lib

### DIFF
--- a/plugins/src/libs/config/CMakeLists.txt
+++ b/plugins/src/libs/config/CMakeLists.txt
@@ -18,4 +18,4 @@
 
 find_package(yaml-cpp 0.5 REQUIRED)
 add_library(config SHARED config.cpp yaml.cpp)
-target_link_libraries(config PRIVATE yaml-cpp)
+target_link_libraries(config PRIVATE core yaml-cpp)


### PR DESCRIPTION
Hi,
I tried to update our setup to use the current refbox with the simulation, there I noticed that the exceptions are not correctly linked, after a quick check in the CMake of the config lib I found that a linking against the core lib is missing. Below is the error that I got prior to this fix.

```
[Err] [Plugin.hh:178] Failed to load plugin /workspaces/logistics/gazebo-rcll/build/plugins//libgps.so: /workspaces/logistics/gazebo-rcll/build/plugins/src/libs/config/libconfig.so: undefined symbol: _ZNK6fawkes9Exception4whatEv
[Err] [Plugin.hh:178] Failed to load plugin /workspaces/logistics/gazebo-rcll/build/plugins//libtag.so: /workspaces/logistics/gazebo-rcll/build/plugins/src/libs/config/libconfig.so: undefined symbol: _ZNK6fawkes9Exception4whatEv
[Err] [Plugin.hh:178] Failed to load plugin /workspaces/logistics/gazebo-rcll/build/plugins//libgps.so: /workspaces/logistics/gazebo-rcll/build/plugins/src/libs/config/libconfig.so: undefined symbol: _ZNK6fawkes9Exception4whatEv
[Err] [Plugin.hh:178] Failed to load plugin /workspaces/logistics/gazebo-rcll/build/plugins//libtag.so: /workspaces/logistics/gazebo-rcll/build/plugins/src/libs/config/libconfig.so: undefined symbol: _ZNK6fawkes9Exception4whatEv
[Err] [Plugin.hh:178] Failed to load plugin /workspaces/logistics/gazebo-rcll/build/plugins//libgps.so: /workspaces/logistics/gazebo-rcll/build/plugins/src/libs/config/libconfig.so: undefined symbol: _ZNK6fawkes9Exception4whatEv
```