### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ include(GNUInstallDirs)
 
 include(third_party/third_party.cmake)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+
 set(USERDIR
     ".config/rcll/gazebo"
     CACHE


### PR DESCRIPTION
Hi,

While testing the compilation on my other PC I found out that the CMake does not specify the C++ version to be used. If a older version of g++ is installed that leads to a lot of errors (like std::optional is non existing and so on). I specify it now to use c++17. Just wanted to let you know, I guess this might save some time for others.