### PR TITLE
Fixes required to build in Fedora 35

### DIFF
--- a/plugins/src/libs/core/threading/thread.cpp
+++ b/plugins/src/libs/core/threading/thread.cpp
@@ -847,7 +847,7 @@ void
 Thread::yield()
 {
 #ifdef __USE_GNU
-	pthread_yield();
+	sched_yield();
 #else
 	usleep(0);
 #endif

--- a/plugins/src/plugins/mps/base_station.cpp
+++ b/plugins/src/plugins/mps/base_station.cpp
@@ -30,6 +30,12 @@
 #include <functional>
 #include <thread>
 
+std::ostream&
+gazebo::operator<<(std::ostream& os, const gazebo::BaseColor& b)
+{
+         return os << static_cast<int>(b);
+}
+
 using namespace gazebo;
 
 BaseStation::BaseStation(physics::ModelPtr _parent, sdf::ElementPtr _sdf) : Mps(_parent, _sdf)

--- a/plugins/src/plugins/mps/base_station.h
+++ b/plugins/src/plugins/mps/base_station.h
@@ -29,6 +29,9 @@ namespace gazebo {
 
 enum class BaseColor { RED = 1, SILVER, BLACK };
 
+std::ostream&
+operator<<(std::ostream& os, const BaseColor& b);
+
 class BaseStation : public Mps
 {
 public:

--- a/plugins/src/plugins/mps/mps.cpp
+++ b/plugins/src/plugins/mps/mps.cpp
@@ -48,6 +48,12 @@ const std::map<std::string, std::string> Mps::name_id_match = {
   {"M-BSI", "tag_161"},  {"M-BSO", "tag_162"},  {"M-DSI", "tag_49"},   {"M-DSO", "tag_50"},
   {"C-SSO", "tag_194"},  {"C-SSI", "tag_193"},  {"M-SSO", "tag_210"},  {"M-SSI", "tag_209"}};
 
+std::ostream&
+gazebo::operator<<(std::ostream& os, const gazebo::MachineSide& m)
+{
+         return os << static_cast<int>(m);
+}
+
 ///Constructor
 Mps::Mps(physics::ModelPtr _parent, sdf::ElementPtr)
 : model_(_parent), name_(model_->GetName()), sclt_in(this), sclt_base(this)

--- a/plugins/src/plugins/mps/mps.h
+++ b/plugins/src/plugins/mps/mps.h
@@ -52,6 +52,10 @@ enum class MachineSide {
 	MIDDLE = 2,
 	OUTPUT = 3,
 };
+
+std::ostream&
+operator<<(std::ostream& os, const MachineSide& m);
+
 /**
    * Plugin to control a simulated MPS
    * @author Frederik Zwilling


### PR DESCRIPTION
This fixes two issues that occur when building in Fedora 35:
 * `pthread_yield` [is deprecated](https://man7.org/linux/man-pages/man3/pthread_yield.3.html).
 * `fmt` does not implicitly treat `enum` as `int` anymore - see the according discussion [here](https://github.com/fmtlib/fmt/issues/1424).