### PR TITLE
add missing inizalization of shutdown_ flag of mps

### DIFF
--- a/plugins/src/plugins/mps/mps.cpp
+++ b/plugins/src/plugins/mps/mps.cpp
@@ -50,7 +50,7 @@ const std::map<std::string, std::string> Mps::name_id_match = {
 
 ///Constructor
 Mps::Mps(physics::ModelPtr _parent, sdf::ElementPtr)
-: model_(_parent), name_(model_->GetName()), sclt_in(this), sclt_base(this)
+: model_(_parent), name_(model_->GetName()), sclt_in(this), sclt_base(this), shutdown_(false)
 {
 	auto sinks = spdlog::default_logger()->sinks();
 	sinks.push_back(


### PR DESCRIPTION
Hi,

I noticed that the shutdown_ flag of mps is not explicitly set to false on constructino, this can lead to a not working MPS.