### PR TITLE
mps: fix class member initialization order

### DIFF
--- a/plugins/src/plugins/mps/mps.cpp
+++ b/plugins/src/plugins/mps/mps.cpp
@@ -56,7 +56,7 @@ gazebo::operator<<(std::ostream& os, const gazebo::MachineSide& m)
 
 ///Constructor
 Mps::Mps(physics::ModelPtr _parent, sdf::ElementPtr)
-: model_(_parent), name_(model_->GetName()), sclt_in(this), sclt_base(this), shutdown_(false)
+: shutdown_(false), model_(_parent), name_(model_->GetName()), sclt_in(this), sclt_base(this)
 {
 	auto sinks = spdlog::default_logger()->sinks();
 	sinks.push_back(


### PR DESCRIPTION
This fixes a bug introduced with PR #53.