### PR TITLE
Switch to Fedora 36

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build_fedora:
     docker:
-      - image: fedora:34
+      - image: fedora:36
     steps:
       - run:
           name: Install dependencies

--- a/plugins/src/CMakeLists.txt
+++ b/plugins/src/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
                                             GREATER_EQUAL 11)
-  list(APPEND GAZEBO_CFLAGS -Wno-range-loop-construct)
+  list(APPEND GAZEBO_CFLAGS -Wno-range-loop-construct -Wno-deprecated-declarations)
 endif()
 
 include_directories(libs)


### PR DESCRIPTION
Fix compiler errors that occur on Fedora 36 and adapt the circleci build config.